### PR TITLE
Register callback component

### DIFF
--- a/EasyLog.cpp
+++ b/EasyLog.cpp
@@ -83,13 +83,26 @@ namespace EasyLog {
         }
     }
     /**
-    *  Processes individual EasyLogItem(s)
-    *  -  This method is responsible for delivering messages to user.
-    *  -  See main.cpp for example case.
-    */
-    /*void EasyLog::processItem(EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp) {
-        std::cerr << "sdf";
-    }*/
+     *  Processes individual EasyLogItem(s)
+     *  -  This method is responsible for registering the callback function used to send messages to user.
+     *  -  See main.cpp for example case.
+     */
+    void EasyLog::registerProcessItemCallback(void (*callback)(EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp), void* proc_item_data) {
+        std::cerr << "EasyLog::registerProcessItemCallback" << std::endl;
+        std::unique_lock<std::mutex> lock(getInstance()._log_queue_mutex);
+        // Set callback
+        getInstance()._on_proc_item_cb = callback;
+    }
+    /**
+     *  Processes individual EasyLogItem(s) if a callback is not present
+     */
+    void EasyLog::processItem(EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp) {
+        if(_on_proc_item_cb != nullptr) {
+            _on_proc_item_cb(type, visibility, msg, time_stamp);
+        } else {
+            std::cerr << "Register a callback to get EasyLogItems!  You received a message." << std::endl;
+        }
+    }
     /** 
     *  Adds formatting and creates the EasyLogItem if direct is false
     */
@@ -219,7 +232,7 @@ namespace EasyLog {
     }
 
     void EasyLog::EasyLogQueueThread::run() {
-        std::cout << "EasyLogQueue Dispatch Start";
+        std::cout << "EasyLogQueue Dispatch Start" << std::endl;
 
         _is_active = true;
         int64_t time_ms = EasyLogUtils::system_msec_time();
@@ -237,7 +250,7 @@ namespace EasyLog {
             }
         }
 
-        std::cout << "EasyLogQueue Dispatch Stop";
+        std::cout << "EasyLogQueue Dispatch Stop" << std::endl;
 
         _is_active = false;
     }

--- a/EasyLog.h
+++ b/EasyLog.h
@@ -55,6 +55,8 @@ namespace EasyLog {
         static void log(EasyLogType type, EasyLogVisibility visibility, const std::string &msg);
         // Formats message with callstack and forwards synchronously, then throws an exception - uses the error channel
         static void logFatal(EasyLogVisibility visibility, const char* msg, ...);
+
+        static void registerProcessItemCallback(void (*callback)(EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp), void* proc_item_data);
         // Return state of _running - This determines whether our EasyLogQueueThread is processing
         bool isRunning();
         // Allow adjustment of thread idle time
@@ -64,8 +66,8 @@ namespace EasyLog {
         bool _running;
         // Max idle time in ms
         int _max_thread_idle_time;
-        // Applications using EasyLog need to implement the processItem function
-        virtual void processItem(EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp) {};
+        // Process EasyLog(s) if no callback exist
+        void processItem(EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp);
     private:
         EasyLog() : _log_queue_thread(this), _running(false), _shutting_down(false), _max_thread_idle_time(MAX_THREAD_IDLE_TIME){};
         // Stop the processing of log items safely
@@ -113,6 +115,11 @@ namespace EasyLog {
         EasyLogQueueThread _log_queue_thread;
         // Current active EasyLog instance - can only be one
         static EasyLog* s_easy_log;
+        // Callback typedef for convenience
+        typedef void (* callback_func)( EasyLogType type, EasyLogVisibility visibility, const char *msg, int64_t time_stamp);
+        // Process log callback / data
+        EasyLog::callback_func _on_proc_item_cb;
+
     };
 } // End namespace
 

--- a/main.cpp
+++ b/main.cpp
@@ -2,17 +2,18 @@
 
 #include <iostream>
 
-class EasyLogSDK : public EasyLog::EasyLog {
-public:
-    virtual void processItem(::EasyLog::EasyLogType type, ::EasyLog::EasyLogVisibility visibility, const char *msg, int64_t time_stamp);
-};
-
 /**
  * EasyLogSDK Implementation
  */
-void EasyLogSDK::processItem(::EasyLog::EasyLogType type, ::EasyLog::EasyLogVisibility visibility, const char *msg, int64_t time_stamp){
+
+class EasyLogSDK {
+public:
+    static void processItemCallback(::EasyLog::EasyLogType type, ::EasyLog::EasyLogVisibility visibility, const char *msg, int64_t time_stamp);
+};
+
+void EasyLogSDK::processItemCallback(::EasyLog::EasyLogType type, ::EasyLog::EasyLogVisibility visibility, const char *msg, int64_t time_stamp){
     // ############
-    //  This is critical for the user to override processItem in their subclass of EasyLog in order to get log messages
+    //  This is critical for the user to implement a callback for EasyLogItem(s) to be received
     // ############
     std::string n_type, n_visibility;
     
@@ -72,15 +73,21 @@ void EasyLogSDK::processItem(::EasyLog::EasyLogType type, ::EasyLog::EasyLogVisi
 *   End EasyLogSDK Implementation
 */
 
+static EasyLogSDK easy_log_sdk;
+
+/**
+ *  Entry point
+ */
 int
 main(int argc, const char* argv[]) {
-    EasyLogSDK::EasyLog &easy_log_sdk = EasyLogSDK::EasyLog::getInstance();
+    EasyLog::EasyLog &easy_log = EasyLog::EasyLog::getInstance();
+    easy_log.registerProcessItemCallback(EasyLogSDK::processItemCallback, &easy_log_sdk);
     //EasyLog::EasyLog &easy_log = EasyLog::EasyLog::getInstance();
-    easy_log_sdk.log(EasyLog::EasyLogType::General, EasyLog::EasyLogVisibility::Public, "Testing public general EasyLog message");
-    easy_log_sdk.log(EasyLog::EasyLogType::Stats, EasyLog::EasyLogVisibility::Protected, "Testing protected stats EasyLog message");
-    easy_log_sdk.log(EasyLog::EasyLogType::Error, EasyLog::EasyLogVisibility::Private, "Testing private error EasyLog message");
+    easy_log.log(EasyLog::EasyLogType::General, EasyLog::EasyLogVisibility::Public, "Testing public general EasyLog message");
+    easy_log.log(EasyLog::EasyLogType::Stats, EasyLog::EasyLogVisibility::Protected, "Testing protected stats EasyLog message");
+    easy_log.log(EasyLog::EasyLogType::Error, EasyLog::EasyLogVisibility::Private, "Testing private error EasyLog message");
     // Wait for EasyLogQueue Dispatch to finish
-    while(easy_log_sdk.isRunning()){}
+    while(easy_log.isRunning()){}
     // End program
     return 0;
 }


### PR DESCRIPTION
Replaces virtual method `processItem` with a callback registration to send back `EasyLogItem(s)`.